### PR TITLE
Fix download path for generated summary

### DIFF
--- a/scan-frontend/app/api/ollama/download/route.ts
+++ b/scan-frontend/app/api/ollama/download/route.ts
@@ -5,7 +5,11 @@ import { createReadStream } from "fs";
 import { join } from "path";
 
 export async function GET() {
-  const filePath = join(process.cwd(), "reports", "summary.docx");
+  // Summary files are written to the "public" directory so they can be
+  // served directly as static assets. The previous path incorrectly
+  // pointed to a non-existent "reports" folder which resulted in a 404
+  // when attempting to download the generated document.
+  const filePath = join(process.cwd(), "public", "summary.docx");
 
   try {
     const stream = createReadStream(filePath);


### PR DESCRIPTION
## Summary
- fix incorrect path for download endpoint

## Testing
- `python3 -m py_compile api_main.py main.py scanner/*.py`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4b24594c8331970902794c76c15f