### PR TITLE
Fix comment typo in docker-compose

### DIFF
--- a/greenbone-community-container/docker-compose.yml
+++ b/greenbone-community-container/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       - gvmd
   # Sets log level of openvas to the set LOG_LEVEL within the env
   # and changes log output to /var/log/openvas instead /var/log/gvm
-  # to reduce likelyhood of unwanted log interferences
+  # to reduce likelihood of unwanted log interferences
   configure-openvas:
     image: registry.community.greenbone.net/community/openvas-scanner:stable
     volumes:


### PR DESCRIPTION
## Summary
- correct a typo in `greenbone-community-container/docker-compose.yml` comment

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684b501fad6c8331a4acda1713c7ea72