### PR TITLE
Fix summary doc download path

### DIFF
--- a/scan-frontend/app/api/ollama/download/route.ts
+++ b/scan-frontend/app/api/ollama/download/route.ts
@@ -5,7 +5,8 @@ import { createReadStream } from "fs";
 import { join } from "path";
 
 export async function GET() {
-  const filePath = join(process.cwd(), "reports", "summary.docx");
+  // summary.docx is generated in the /public directory
+  const filePath = join(process.cwd(), "public", "summary.docx");
 
   try {
     const stream = createReadStream(filePath);


### PR DESCRIPTION
## Summary
- adjust document download path to match generation folder

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b50106e28833197ca80253113140e